### PR TITLE
fix Grunt on unix

### DIFF
--- a/_references.ts
+++ b/_references.ts
@@ -37,8 +37,8 @@
 /// <reference path="src/main.ts" />
 
 /// <reference path="src/widgets/directives/directives.ts" />
-/// <reference path="src/widgets/directives/checklistdirective.ts" />
-/// <reference path="src/widgets/directives/simplepagingdirective.ts" />
-/// <reference path="src/widgets/directives/singleselectdirective.ts" />
+/// <reference path="src/widgets/directives/ChecklistDirective.ts" />
+/// <reference path="src/widgets/directives/SimplePagingDirective.ts" />
+/// <reference path="src/widgets/directives/SingleselectDirective.ts" />
 
 


### PR DESCRIPTION
fix file case to avoid this error when building:

```
mathieu on ElasticUI:master ⚡ grunt
Running "typescript:dist" (typescript) task
>> /data/users/mathieu/prelinker-debug/app/bower_components/ElasticUI/_references.ts(40,1):
>> error TS5007: Cannot resolve referenced file: 'src/widgets/directives/checklistdirective.ts'.
>> /data/users/mathieu/prelinker-debug/app/bower_components/ElasticUI/_references.ts(41,1):
>> error TS5007: Cannot resolve referenced file: 'src/widgets/directives/simplepagingdirective.ts'.
>> /data/users/mathieu/prelinker-debug/app/bower_components/ElasticUI/_references.ts(42,1):
>> error TS5007: Cannot resolve referenced file: 'src/widgets/directives/singleselectdirective.ts'.
```
