### PR TITLE
prohibit triggering a query when the query attribute in the indexVM i…

### DIFF
--- a/src/controllers/IndexController.ts
+++ b/src/controllers/IndexController.ts
@@ -43,15 +43,51 @@ module elasticui.controllers {
             $scope.indexVM = this.indexVM;
             $scope.ejs = $window.ejs; // so we can use ejs in attributes etc. TODO: better to have a ejs service instead of loading from window
             $scope.filters = this.filters;
-            $scope.$watchCollection('indexVM.filters.ejsObjects', () => { this.indexVM.page = 1; this.search() });
-            $scope.$watchCollection('indexVM.aggregationProviders.objects', () => this.search());
+            $scope.$watchCollection('indexVM.filters.ejsObjects', () => { this.indexVM.page = 1; 
+                if (indexVM.query != null) {
+                    this.search();
+                }
+            });
+            $scope.$watchCollection('indexVM.aggregationProviders.objects', () => 
+                 if (this.indexVM.query != null) {
+                    this.search();
+                });
 
-            $scope.$watch('indexVM.host', () => { if (this.indexVM.host != null && es.setHost(this.indexVM.host)) { this.search(); } });
-            $scope.$watch('indexVM.sort', () => { this.indexVM.page = 1; this.search() });
-            $scope.$watch('indexVM.page', () => this.search());
-            $scope.$watch('indexVM.index', () => this.search());
-            $scope.$watch('indexVM.query', () => this.search());
-            $scope.$watch('indexVM.highlight', () => this.search());
+            $scope.$watch('indexVM.host', () => {
+                if (this.indexVM.host != null && es.setHost(this.indexVM.host) 
+                     && this.indexVM.query != null) {
+                    this.search();
+                }
+            });
+            $scope.$watch('indexVM.sort', () => {
+                this.indexVM.page = 1; 
+                if (this.indexVM.query != null) {
+                    this.search();
+                }                
+            });
+            $scope.$watch('indexVM.page', () => 
+                if (this.indexVM.query != null) {
+                    this.search();
+                }            
+            );
+            $scope.$watch('indexVM.index', () => 
+                if (this.indexVM.query != null) {
+                    this.search();
+                }
+            );
+            $scope.$watch('indexVM.query', (newQuery, oldQuery) => {
+            if (oldQuery != null && newQuery == null) {
+                        search();
+                    }
+            if ( this.indexVM.query != null) {
+                        search();
+                } 
+            });
+            $scope.$watch('indexVM.highlight', () => 
+                if (this.indexVM.query != null) {
+                    this.search();
+                }
+            );
 
             $timeout(() => this.loaded(), 200); // TODO: find better way to recognize loading of app
         }


### PR DESCRIPTION
…s null

There is a special case :
                  // when we launch the search when the query is not null except the case when we query with 
                 // an empty string after we had already launched a search 
                 // ex: query with string1 we got result after we remove the key and launch the search
                // we should get all the results