### PR TITLE
Improve results from slow query's.

### DIFF
--- a/dist/elasticui.js
+++ b/dist/elasticui.js
@@ -697,6 +697,10 @@ var elasticui;
                     this.refreshPromise.abort();
                     this.refreshPromise = null;
                 }
+                if (this.searchPromise != null) {
+                    this.searchPromise.abort();
+                    this.searchPromise = null;
+                }                
                 this.indexVM.loading = true;
                 this.searchPromise = this.getSearchPromise();
                 this.searchPromise.then(function (body) {


### PR DESCRIPTION
Fix show results from first slow query in second query.

If first query it's slow returning/printing results, when I make a new query (with less results) prints results from the first + second.