### PR TITLE
Initialise the controllers module correctly

### DIFF
--- a/src/controllers/controllers.ts
+++ b/src/controllers/controllers.ts
@@ -1,1 +1,3 @@
-angular.module('elasticui.controllers', []).controller(elasticui.controllers)
+module elasticui.controllers {
+    export var controllers: ng.IModule = angular.module('elasticui.controllers', []);
+}


### PR DESCRIPTION
This works around the issue I'm seeing at module load (registering the module without initialising it correctly first, as with all others).
I'm using Angular 1.4.3, elasticjs 1.2.0, elasticsearch.angular.js 6.0.0.
Here's a backtrace:

<pre>
Uncaught Error: [$injector:modulerr] Failed to instantiate module h.app.search due to:
Error: [$injector:modulerr] Failed to instantiate module elasticui due to:
Error: [$injector:nomod] Module 'elasticui' is not available! You either misspelled the module name or forgot to load it. If registering a module ensure that you specify the dependencies as the second argument.
http://errors.angularjs.org/1.3.0-build.3042+sha.76e57a7/$injector/nomod?p0=elasticui
    at chrome-extension://ighdmehidhipcmcojjgiloacoafjmpfk/dist/hint.js:99:12
    at chrome-extension://ighdmehidhipcmcojjgiloacoafjmpfk/dist/hint.js:194:17
    at ensure (chrome-extension://ighdmehidhipcmcojjgiloacoafjmpfk/dist/hint.js:118:38)
    at module (chrome-extension://ighdmehidhipcmcojjgiloacoafjmpfk/dist/hint.js:192:14)
    at angular.module (chrome-extension://ighdmehidhipcmcojjgiloacoafjmpfk/dist/hint.js:1616:31)
    at angular.module (chrome-extension://ighdmehidhipcmcojjgiloacoafjmpfk/dist/hint.js:1757:38)
    at http://localhost:8000/static/angular/angular.js:4362:22
    at forEach (http://localhost:8000/static/angular/angular.js:336:20)
    at loadModules (http://localhost:8000/static/angular/angular.js:4346:5)
    at http://localhost:8000/static/angular/angular.js:4363:40
http://errors.angularjs.org/1.4.3/$injector/modulerr?p0=elasticui&p1=Error%…0http%3A%2F%2Flocalhost%3A8000%2Fstatic%2Fangular%2Fangular.js%3A4363%3A40
    at REGEX_STRING_REGEXP (http://localhost:8000/static/angular/angular.js:68:12)
    at http://localhost:8000/static/angular/angular.js:4385:15
    at forEach (http://localhost:8000/static/angular/angular.js:336:20)
    at loadModules (http://localhost:8000/static/angular/angular.js:4346:5)
    at http://localhost:8000/static/angular/angular.js:4363:40
    at forEach (http://localhost:8000/static/angular/angular.js:336:20)
    at loadModules (http://localhost:8000/static/angular/angular.js:4346:5)
    at createInjector (http://localhost:8000/static/angular/angular.js:4272:11)
    at doBootstrap (http://localhost:8000/static/angular/angular.js:1630:20)
    at Object.angular.resumeBootstrap (http://localhost:8000/static/angular/angular.js:1659:12)
http://errors.angularjs.org/1.4.3/$injector/modulerr?p0=h.app.search&p…(http%3A%2F%2Flocalhost%3A8000%2Fstatic%2Fangular%2Fangular.js%3A1659%3A12)
</pre>